### PR TITLE
Traps

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,8 +1,2 @@
-[unstable]
-extra-link-arg = true
-#build-std = ["core", "alloc"]
-
 [alias]
 xtask = "run --package xtask --"
-
-[target.x86_64-unknown-none-elf]

--- a/theon/src/main.rs
+++ b/theon/src/main.rs
@@ -25,7 +25,7 @@ mod x86_64;
 #[cfg_attr(not(test), no_mangle)]
 pub extern "C" fn main(mbinfo_phys: u64) -> ! {
     x86_64::init::start(mbinfo_phys);
-    panic!("main: end reached");
+    panic!("main: trapstubs = {:#x}", arch::trap::stubs as u64);
 }
 
 #[no_mangle]

--- a/theon/src/x86_64/link.ld
+++ b/theon/src/x86_64/link.ld
@@ -16,6 +16,8 @@ SECTIONS {
 	{
 		*(.text.boot)
 		*(.text*)
+		. = ALIGN(4096);
+		*(.trap*)
 	}
 	. = ALIGN(4096);
 	PROVIDE(etext = .);

--- a/x86_64/Cargo.toml
+++ b/x86_64/Cargo.toml
@@ -14,5 +14,7 @@ edition = "2018"
 
 [dependencies]
 bitflags = "*"
+bitstruct = "*"
+seq-macro = "*"
 x86 = "*"
 zerocopy = "*"

--- a/x86_64/src/lib.rs
+++ b/x86_64/src/lib.rs
@@ -5,12 +5,15 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+#![feature(asm)]
+#![feature(naked_functions)]
 #![cfg_attr(not(test), no_std)]
 
 use zerocopy::FromBytes;
 
 pub mod cpu;
 pub mod io;
+pub mod trap;
 pub mod vm;
 
 ///

--- a/x86_64/src/trap.rs
+++ b/x86_64/src/trap.rs
@@ -1,0 +1,182 @@
+use seq_macro::seq;
+
+#[derive(Copy, Clone, Debug)]
+#[repr(C)]
+pub struct Frame {
+    // Pushed by software.
+    rax: u64,
+    rbx: u64,
+    rcx: u64,
+    rdx: u64,
+    rsi: u64,
+    rdi: u64,
+    rbp: u64,
+    r8: u64,
+    r9: u64,
+    r10: u64,
+    r11: u64,
+    r12: u64,
+    r13: u64,
+    r14: u64,
+    r15: u64,
+
+    // It is arguable whether we should care about
+    // these registers.  x86 segmentation (aside from
+    // FS and GS) isn't used once we're in long mode,
+    // and rxv64 doesn't support real or compatibility
+    // mode, so these are effectively unused.
+    //
+    // Regardless, they exist, so we save and restore
+    // them.  Some kernels do this, some do not.  Note
+    // that %fs and %gs are special.
+    ds: u64, // Really these are u16s, but
+    es: u64, // we waste a few bytes to keep
+    fs: u64, // the stack aligned.  Thank
+    gs: u64, // you, x86 segmentation.
+
+    vector: u64,
+
+    // Sometimes pushed by hardware.
+    pub error: u64,
+
+    // Pushed by hardware.
+    pub rip: u64,
+    cs: u64,
+    rflags: u64,
+    rsp: u64,
+    ss: u64,
+}
+
+const TRAPFRAME_VECTOR_OFFSET: usize = 0x98;
+const TRAPFRAME_CS_OFFSET: usize = 0xB0;
+
+macro_rules! gen_stub {
+    ($vecnum:expr) => {
+        concat!(r#".balign 8; pushq $0; callq {trap}; .byte "#, stringify!($vecnum), ";")
+    };
+    ($vecnum:expr, err) => {
+        concat!(r#".balign 8; callq {trap}; .byte "#, stringify!($vecnum), ";")
+    };
+}
+
+macro_rules! gen_trap_stub {
+    // These cases include hardware-generated error words
+    // on the trap frame
+    (8) => {
+        gen_stub!(8, err)
+    };
+    (10) => {
+        gen_stub!(10, err)
+    };
+    (11) => {
+        gen_stub!(11, err)
+    };
+    (12) => {
+        gen_stub!(12, err)
+    };
+    (13) => {
+        gen_stub!(13, err)
+    };
+    (14) => {
+        gen_stub!(14, err)
+    };
+    (17) => {
+        gen_stub!(17, err)
+    };
+    // No hardware error
+    ($num:expr) => {
+        gen_stub!($num)
+    };
+}
+
+#[allow(dead_code)]
+#[link_section = ".trap"]
+#[naked]
+pub unsafe extern "C" fn stubs() -> ! {
+    asm!(
+        seq!(N in 0..=255 {
+            concat!( #( gen_trap_stub!(N), )* )
+        }),
+        trap = sym trap, options(att_syntax, noreturn));
+}
+
+#[link_section = ".trap"]
+#[no_mangle]
+#[naked]
+pub unsafe extern "C" fn trap() -> ! {
+    asm!(r#"
+        // Save the x86 segmentation registers.
+        subq $32, %rsp
+        movq $0, (%rsp);
+        movw %ds, (%rsp);
+        movq $0, 8(%rsp);
+        movw %es, 8(%rsp);
+        movq $0, 16(%rsp);
+        movw %fs, 16(%rsp);
+        movq $0, 24(%rsp);
+        movw %gs, 24(%rsp);
+        pushq %r15;
+        pushq %r14;
+        pushq %r13;
+        pushq %r12;
+        pushq %r11;
+        pushq %r10;
+        pushq %r9;
+        pushq %r8;
+        pushq %rbp;
+        pushq %rdi;
+        pushq %rsi;
+        pushq %rdx;
+        pushq %rcx;
+        pushq %rbx;
+        pushq %rax;
+        movq {vector_offset}(%rsp), %rdi;
+	movzbq (%rdi), %rdi;
+	movq %rdi, {vector_offset}(%rsp);
+        movq %rsp, %rsi;
+        cmpq ${ktext_sel}, {cs_offset}(%rsp);
+        je 1f;
+        swapgs;
+        1:
+        callq {dispatch};
+        cmpq ${ktext_sel}, {cs_offset}(%rsp);
+        je 1f;
+        swapgs;
+        1:
+        popq %rax;
+        popq %rbx;
+        popq %rcx;
+        popq %rdx;
+        popq %rsi;
+        popq %rdi;
+        popq %rbp;
+        popq %r8;
+        popq %r9;
+        popq %r10;
+        popq %r11;
+        popq %r12;
+        popq %r13;
+        popq %r14;
+        popq %r15;
+        // If necessary, %gs is restored via swapgs above.
+        // %fs is special.  We ought to save it and restore
+        // it, should userspace ever use green threads.
+        //movw 24(%rsp), %gs;
+        movw 16(%rsp), %fs;
+        movw 8(%rsp), %es;
+        movw (%rsp), %ds;
+        addq $32, %rsp;
+        // Pop alignment word and error.
+        addq $16, %rsp;
+        iretq
+        "#,
+        ktext_sel = const 8,
+        cs_offset = const TRAPFRAME_CS_OFFSET,
+        vector_offset = const TRAPFRAME_VECTOR_OFFSET,
+        dispatch = sym dispatch,
+        options(att_syntax, noreturn));
+}
+
+fn dispatch(_vector: u8, _trap_frame: &mut Frame) -> u32 {
+    0
+}

--- a/x86_64/src/vm.rs
+++ b/x86_64/src/vm.rs
@@ -85,11 +85,11 @@ impl Clone for Entry {
 }
 
 ///
-/// The nature of the recursive entry in the PML4 is that the
-/// nodes in the paging radix trees are all accessable via fixed
-/// locations in the virtual address space.  The constants below
-/// are the beginnings of the virtual address regions for all
-/// entries.
+/// The nature of the recursive entry in the table root is that
+/// the nodes in the paging radix trees are all accessable via
+/// fixed locations in the virtual address space.  The constants
+/// below are the beginnings of the virtual address regions for
+/// all entries.
 ///
 /// This also means that radix nodes at any given level of the
 /// tree for contiguous regions of the virtual address space are


### PR DESCRIPTION
Start handling traps: interrupts, exceptions, and faults. This adds the skeletal x86_64 substrate for trap stubs and so forth.

Also, a few minor cleanups.