### PR TITLE
Enable `strict_provenance` everywhere.

### DIFF
--- a/devices/src/link.ld
+++ b/devices/src/link.ld
@@ -14,22 +14,27 @@ SECTIONS {
 
 	.text . :
 	{
-		*(.text.boot)
-		*(.text)
+		*(.text*)
 	}
 	. = ALIGN(4096);
 	PROVIDE(etext = .);
 
 	.rodata . :
 	{
-		*(.rodata)
+		*(.rodata*)
 	}
 	. = ALIGN(4096);
 	PROVIDE(erodata = .);
 
+	.got . :
+	{
+		*(.got*)
+	}
+	. = ALIGN(4096);
+
 	.data . :
 	{
-		*(.data)
+		*(.data*)
 	}
 	. = ALIGN(4096);
 	PROVIDE(edata = .);
@@ -40,6 +45,5 @@ SECTIONS {
 		*(COMMON)
 	}
 	. = ALIGN(4096);
-
 	PROVIDE(end = .);
 }

--- a/devices/src/main.rs
+++ b/devices/src/main.rs
@@ -7,6 +7,7 @@
 
 #![feature(lang_items)]
 #![feature(start)]
+#![feature(strict_provenance)]
 #![cfg_attr(not(test), no_main)]
 #![cfg_attr(not(test), no_std)]
 

--- a/global/src/link.ld
+++ b/global/src/link.ld
@@ -14,22 +14,27 @@ SECTIONS {
 
 	.text . :
 	{
-		*(.text.boot)
-		*(.text)
+		*(.text*)
 	}
 	. = ALIGN(4096);
 	PROVIDE(etext = .);
 
 	.rodata . :
 	{
-		*(.rodata)
+		*(.rodata*)
 	}
 	. = ALIGN(4096);
 	PROVIDE(erodata = .);
 
+	.got . :
+	{
+		*(.got*)
+	}
+	. = ALIGN(4096);
+
 	.data . :
 	{
-		*(.data)
+		*(.data*)
 	}
 	. = ALIGN(4096);
 	PROVIDE(edata = .);
@@ -40,6 +45,5 @@ SECTIONS {
 		*(COMMON)
 	}
 	. = ALIGN(4096);
-
 	PROVIDE(end = .);
 }

--- a/global/src/main.rs
+++ b/global/src/main.rs
@@ -7,6 +7,7 @@
 
 #![feature(lang_items)]
 #![feature(start)]
+#![feature(strict_provenance)]
 #![cfg_attr(not(test), no_main)]
 #![cfg_attr(not(test), no_std)]
 

--- a/lib/x86_64-unknown-none-elf.json
+++ b/lib/x86_64-unknown-none-elf.json
@@ -9,6 +9,8 @@
 	"arch": "x86_64",
 	"os": "none",
 	"executables": true,
+	"relocation-model": "pie",
+	"code-model": "small",
 	"disable-redzone": true,
 	"features": "-mmx,-sse,+soft-float",
 	"panic-strategy": "abort",

--- a/libhypatia/src/lib.rs
+++ b/libhypatia/src/lib.rs
@@ -5,6 +5,7 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+#![feature(strict_provenance)]
 #![cfg_attr(test, allow(dead_code))]
 #![cfg_attr(not(test), no_std)]
 

--- a/memory/src/link.ld
+++ b/memory/src/link.ld
@@ -14,22 +14,27 @@ SECTIONS {
 
 	.text . :
 	{
-		*(.text.boot)
-		*(.text)
+		*(.text*)
 	}
 	. = ALIGN(4096);
 	PROVIDE(etext = .);
 
 	.rodata . :
 	{
-		*(.rodata)
+		*(.rodata*)
 	}
 	. = ALIGN(4096);
 	PROVIDE(erodata = .);
 
+	.got . :
+	{
+		*(.got*)
+	}
+	. = ALIGN(4096);
+
 	.data . :
 	{
-		*(.data)
+		*(.data*)
 	}
 	. = ALIGN(4096);
 	PROVIDE(edata = .);
@@ -40,6 +45,5 @@ SECTIONS {
 		*(COMMON)
 	}
 	. = ALIGN(4096);
-
 	PROVIDE(end = .);
 }

--- a/memory/src/main.rs
+++ b/memory/src/main.rs
@@ -7,6 +7,7 @@
 
 #![feature(lang_items)]
 #![feature(start)]
+#![feature(strict_provenance)]
 #![cfg_attr(not(test), no_main)]
 #![cfg_attr(not(test), no_std)]
 

--- a/monitor/Cargo.toml
+++ b/monitor/Cargo.toml
@@ -13,3 +13,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+uart = { path = "../uart" }
+arch = { package = "x86_64", path = "../x86_64" }

--- a/monitor/src/link.ld
+++ b/monitor/src/link.ld
@@ -7,29 +7,34 @@
  * https://opensource.org/licenses/MIT.
  */
 
-ENTRY(main)
+ENTRY(init)
 
 SECTIONS {
 	. = 0xFFFFFA0000000000;
 
 	.text . :
 	{
-		*(.text.boot)
-		*(.text)
+		*(.text*)
 	}
 	. = ALIGN(4096);
 	PROVIDE(etext = .);
 
 	.rodata . :
 	{
-		*(.rodata)
+		*(.rodata*)
 	}
 	. = ALIGN(4096);
 	PROVIDE(erodata = .);
 
+	.got . :
+	{
+		*(.got*)
+	}
+	. = ALIGN(4096);
+
 	.data . :
 	{
-		*(.data)
+		*(.data*)
 	}
 	. = ALIGN(4096);
 	PROVIDE(edata = .);
@@ -40,6 +45,5 @@ SECTIONS {
 		*(COMMON)
 	}
 	. = ALIGN(4096);
-
 	PROVIDE(end = .);
 }

--- a/monitor/src/main.rs
+++ b/monitor/src/main.rs
@@ -10,8 +10,11 @@
 #![cfg_attr(not(test), no_main)]
 #![cfg_attr(not(test), no_std)]
 
+#[no_mangle]
 #[start]
-pub extern "C" fn init() {}
+pub extern "C" fn init() {
+    uart::panic_println!("Hi from the monitor");
+}
 
 #[cfg(not(test))]
 mod runtime;

--- a/monitor/src/main.rs
+++ b/monitor/src/main.rs
@@ -7,6 +7,7 @@
 
 #![feature(lang_items)]
 #![feature(start)]
+#![feature(strict_provenance)]
 #![cfg_attr(not(test), no_main)]
 #![cfg_attr(not(test), no_std)]
 

--- a/scheduler/src/link.ld
+++ b/scheduler/src/link.ld
@@ -14,22 +14,27 @@ SECTIONS {
 
 	.text . :
 	{
-		*(.text.boot)
-		*(.text)
+		*(.text*)
 	}
 	. = ALIGN(4096);
 	PROVIDE(etext = .);
 
 	.rodata . :
 	{
-		*(.rodata)
+		*(.rodata*)
 	}
 	. = ALIGN(4096);
 	PROVIDE(erodata = .);
 
+	.got . :
+	{
+		*(.got*)
+	}
+	. = ALIGN(4096);
+
 	.data . :
 	{
-		*(.data)
+		*(.data*)
 	}
 	. = ALIGN(4096);
 	PROVIDE(edata = .);
@@ -40,6 +45,5 @@ SECTIONS {
 		*(COMMON)
 	}
 	. = ALIGN(4096);
-
 	PROVIDE(end = .);
 }

--- a/scheduler/src/main.rs
+++ b/scheduler/src/main.rs
@@ -7,6 +7,7 @@
 
 #![feature(lang_items)]
 #![feature(start)]
+#![feature(strict_provenance)]
 #![cfg_attr(not(test), no_main)]
 #![cfg_attr(not(test), no_std)]
 

--- a/supervisor/src/link.ld
+++ b/supervisor/src/link.ld
@@ -21,14 +21,20 @@ SECTIONS {
 
 	.rodata . :
 	{
-		*(.rodata)
+		*(.rodata*)
 	}
 	. = ALIGN(4096);
 	PROVIDE(erodata = .);
 
+	.got . :
+	{
+		*(.got*)
+	}
+	. = ALIGN(4096);
+
 	.data . :
 	{
-		*(.data)
+		*(.data*)
 	}
 	. = ALIGN(4096);
 	PROVIDE(edata = .);
@@ -39,6 +45,5 @@ SECTIONS {
 		*(COMMON)
 	}
 	. = ALIGN(4096);
-
 	PROVIDE(end = .);
 }

--- a/supervisor/src/main.rs
+++ b/supervisor/src/main.rs
@@ -7,6 +7,7 @@
 
 #![feature(lang_items)]
 #![feature(start)]
+#![feature(strict_provenance)]
 #![cfg_attr(not(test), no_main)]
 #![cfg_attr(not(test), no_std)]
 

--- a/system/src/link.ld
+++ b/system/src/link.ld
@@ -14,22 +14,27 @@ SECTIONS {
 
 	.text . :
 	{
-		*(.text.boot)
-		*(.text)
+		*(.text*)
 	}
 	. = ALIGN(4096);
 	PROVIDE(etext = .);
 
 	.rodata . :
 	{
-		*(.rodata)
+		*(.rodata*)
 	}
 	. = ALIGN(4096);
 	PROVIDE(erodata = .);
 
+	.got . :
+	{
+		*(.got*)
+	}
+	. = ALIGN(4096);
+
 	.data . :
 	{
-		*(.data)
+		*(.data*)
 	}
 	. = ALIGN(4096);
 	PROVIDE(edata = .);
@@ -40,6 +45,5 @@ SECTIONS {
 		*(COMMON)
 	}
 	. = ALIGN(4096);
-
 	PROVIDE(end = .);
 }

--- a/system/src/main.rs
+++ b/system/src/main.rs
@@ -7,6 +7,7 @@
 
 #![feature(lang_items)]
 #![feature(start)]
+#![feature(strict_provenance)]
 #![cfg_attr(not(test), no_main)]
 #![cfg_attr(not(test), no_std)]
 

--- a/theon/src/main.rs
+++ b/theon/src/main.rs
@@ -10,6 +10,7 @@
 #![feature(lang_items)]
 #![feature(naked_functions)]
 #![feature(start)]
+#![feature(strict_provenance)]
 #![cfg_attr(not(test), no_main)]
 #![cfg_attr(not(test), no_std)]
 

--- a/trace/src/link.ld
+++ b/trace/src/link.ld
@@ -14,22 +14,28 @@ SECTIONS {
 
 	.text . :
 	{
-		*(.text.boot)
-		*(.text)
+		*(.text*)
 	}
 	. = ALIGN(4096);
 	PROVIDE(etext = .);
 
 	.rodata . :
 	{
-		*(.rodata)
+		*(.rodata*)
 	}
 	. = ALIGN(4096);
 	PROVIDE(erodata = .);
 
+	.got . :
+	{
+		*(.got*)
+	}
+	. = ALIGN(4096);
+
 	.data . :
 	{
-		*(.data)
+		*(.data*)
+		*(.got*)
 	}
 	. = ALIGN(4096);
 	PROVIDE(edata = .);
@@ -40,6 +46,5 @@ SECTIONS {
 		*(COMMON)
 	}
 	. = ALIGN(4096);
-
 	PROVIDE(end = .);
 }

--- a/trace/src/main.rs
+++ b/trace/src/main.rs
@@ -7,6 +7,7 @@
 
 #![feature(lang_items)]
 #![feature(start)]
+#![feature(strict_provenance)]
 #![cfg_attr(not(test), no_main)]
 #![cfg_attr(not(test), no_std)]
 

--- a/uart/src/lib.rs
+++ b/uart/src/lib.rs
@@ -5,6 +5,7 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+#![feature(strict_provenance)]
 #![cfg_attr(not(test), no_std)]
 
 mod x86_64;

--- a/vcpu/src/link.ld
+++ b/vcpu/src/link.ld
@@ -14,22 +14,28 @@ SECTIONS {
 
 	.text . :
 	{
-		*(.text.boot)
-		*(.text)
+		*(.text*)
 	}
 	. = ALIGN(4096);
 	PROVIDE(etext = .);
 
 	.rodata . :
 	{
-		*(.rodata)
+		*(.rodata*)
 	}
 	. = ALIGN(4096);
 	PROVIDE(erodata = .);
 
+	.got . :
+	{
+		*(.got*)
+	}
+	. = ALIGN(4096);
+
 	.data . :
 	{
-		*(.data)
+		*(.data*)
+		*(.got*)
 	}
 	. = ALIGN(4096);
 	PROVIDE(edata = .);
@@ -40,6 +46,5 @@ SECTIONS {
 		*(COMMON)
 	}
 	. = ALIGN(4096);
-
 	PROVIDE(end = .);
 }

--- a/vcpu/src/main.rs
+++ b/vcpu/src/main.rs
@@ -7,6 +7,7 @@
 
 #![feature(lang_items)]
 #![feature(start)]
+#![feature(strict_provenance)]
 #![cfg_attr(not(test), no_main)]
 #![cfg_attr(not(test), no_std)]
 

--- a/vm/src/link.ld
+++ b/vm/src/link.ld
@@ -14,22 +14,28 @@ SECTIONS {
 
 	.text . :
 	{
-		*(.text.boot)
-		*(.text)
+		*(.text*)
 	}
 	. = ALIGN(4096);
 	PROVIDE(etext = .);
 
 	.rodata . :
 	{
-		*(.rodata)
+		*(.rodata*)
 	}
 	. = ALIGN(4096);
 	PROVIDE(erodata = .);
 
+	.got . :
+	{
+		*(.got*)
+	}
+	. = ALIGN(4096);
+
 	.data . :
 	{
-		*(.data)
+		*(.data*)
+		*(.got*)
 	}
 	. = ALIGN(4096);
 	PROVIDE(edata = .);
@@ -40,6 +46,5 @@ SECTIONS {
 		*(COMMON)
 	}
 	. = ALIGN(4096);
-
 	PROVIDE(end = .);
 }

--- a/vm/src/main.rs
+++ b/vm/src/main.rs
@@ -7,6 +7,7 @@
 
 #![feature(lang_items)]
 #![feature(start)]
+#![feature(strict_provenance)]
 #![cfg_attr(not(test), no_main)]
 #![cfg_attr(not(test), no_std)]
 

--- a/x86_64/src/lib.rs
+++ b/x86_64/src/lib.rs
@@ -48,6 +48,7 @@
 #![feature(assert_matches)]
 #![feature(naked_functions)]
 #![feature(step_trait)]
+#![feature(strict_provenance)]
 #![cfg_attr(not(test), no_std)]
 
 use core::convert::TryFrom;


### PR DESCRIPTION
Best to get ahead of this before we have a lot of code doing type casting between usize and pointers.