### PR TITLE
More changes for strict_provenance.

### DIFF
--- a/theon/src/main.rs
+++ b/theon/src/main.rs
@@ -162,8 +162,8 @@ pub extern "C" fn main(mbinfo_phys: u64) -> ! {
 fn theon_fits(regions: &[Region]) -> bool {
     assert!(theon::end_addr() < theon::vaddr(BINARY_LOAD_REGION_START));
     for region in regions.iter().filter(|&r| r.typ == Type::RAM) {
-        if region.start <= BINARY_LOAD_REGION_START.address()
-            && BINARY_LOAD_REGION_END.address() <= region.end
+        if region.start <= BINARY_LOAD_REGION_START.addr()
+            && BINARY_LOAD_REGION_END.addr() <= region.end
         {
             return true;
         }
@@ -233,7 +233,7 @@ fn load(name: &str, typ: BinaryType, bytes: &[u8], region: Range<HPA>) -> Result
             let page = allocate().expect("allocated data page");
             if !src.is_empty() {
                 let len = usize::min(src.len(), Page4K::SIZE);
-                let dst = page.vaddr().address() as *mut u8;
+                let dst = page.vaddr().addr() as *mut u8;
                 unsafe {
                     core::ptr::copy_nonoverlapping(src.as_ptr(), dst, len);
                 }

--- a/theon/src/theon.rs
+++ b/theon/src/theon.rs
@@ -23,5 +23,5 @@ pub(crate) const VZERO: usize = 0xFFFF_8000_0000_0000;
 /// Returns the raw virtual address of the given HPA relative
 /// to  theon's address space.
 pub(crate) const fn vaddr(hpa: HPA) -> usize {
-    hpa.address() as usize + VZERO
+    hpa.addr() as usize + VZERO
 }

--- a/theon/src/theon.rs
+++ b/theon/src/theon.rs
@@ -14,7 +14,7 @@ pub(crate) fn end_addr() -> usize {
     extern "C" {
         static end: [u8; 0];
     }
-    unsafe { end.as_ptr() as usize }
+    unsafe { end.as_ptr().addr() }
 }
 
 /// The start of Theon's virtual address space.

--- a/theon/src/x86_64/multiboot1.rs
+++ b/theon/src/x86_64/multiboot1.rs
@@ -66,7 +66,7 @@ pub(crate) struct MultibootModule<'a> {
 
 impl<'a> MultibootModule<'a> {
     fn region(&self) -> memory::Region {
-        let phys_start = self.bytes.as_ptr() as usize - theon::VZERO;
+        let phys_start = self.bytes.as_ptr().addr() - theon::VZERO;
         let phys_end = phys_start.wrapping_add(self.bytes.len());
         memory::Region { start: phys_start as u64, end: phys_end as u64, typ: memory::Type::Module }
     }

--- a/x86_64/src/gdt.rs
+++ b/x86_64/src/gdt.rs
@@ -80,7 +80,7 @@ impl GDT {
     ///
     /// Called on a valid GDT.
     unsafe fn lgdt(&self) {
-        let base = self as *const _ as usize as u64;
+        let base = u64::try_from((self as *const Self).addr()).unwrap();
         const LIMIT: u16 = core::mem::size_of::<GDT>() as u16 - 1;
         asm!(r#"
             subq $16, %rsp;

--- a/x86_64/src/idt.rs
+++ b/x86_64/src/idt.rs
@@ -49,7 +49,7 @@ impl IDT {
     /// Early code assumes a good stack and resets the IDT pointer
     /// on the local processor.
     pub unsafe fn load(&mut self) {
-        let base = self as *mut _ as u64;
+        let base = (self as *mut Self).addr() as u64;
         const LIMIT: u16 = (core::mem::size_of::<IDT>() - 1) as u16;
         core::arch::asm!(r#"
             subq $16, %rsp;

--- a/x86_64/src/lib.rs
+++ b/x86_64/src/lib.rs
@@ -92,7 +92,7 @@ impl HPA {
     }
 
     /// Returns the address of this HPA as a u64.
-    pub const fn address(self) -> u64 {
+    pub const fn addr(self) -> u64 {
         self.0
     }
 
@@ -114,7 +114,7 @@ pub trait Page {
     fn vaddr(&self) -> Self::VPageAddrType;
 
     fn frame(&self) -> Self::FrameType {
-        let addr = self.vaddr().address();
+        let addr = self.vaddr().addr();
         let pfa = vm::translate(addr);
         Self::FrameType::new(pfa)
     }
@@ -251,7 +251,7 @@ pub trait VPageAddr: Sized + Debug + Clone + Copy {
         Self::new(va.wrapping_add(Self::PageType::MASK) & !Self::PageType::MASK)
     }
 
-    fn address(self) -> usize;
+    fn addr(self) -> usize;
 }
 
 /// A type representing a 4KiB-aligned page address.
@@ -267,7 +267,7 @@ impl VPageAddr for V4KA {
         V4KA(va)
     }
 
-    fn address(self) -> usize {
+    fn addr(self) -> usize {
         self.0
     }
 }
@@ -302,7 +302,7 @@ mod v4ka_tests {
         assert_eq!(V4KA::steps_between(&start, &end), Some(0));
 
         let end = V4KA::new_round_up(1);
-        assert_eq!(end.address(), 4096);
+        assert_eq!(end.addr(), 4096);
         assert_eq!(V4KA::steps_between(&start, &end), Some(1));
 
         let end = V4KA::new(16 * KIB);
@@ -325,7 +325,7 @@ impl VPageAddr for V2MA {
         V2MA(va)
     }
 
-    fn address(self) -> usize {
+    fn addr(self) -> usize {
         self.0
     }
 }
@@ -362,7 +362,7 @@ impl VPageAddr for V1GA {
         V1GA(va)
     }
 
-    fn address(self) -> usize {
+    fn addr(self) -> usize {
         self.0
     }
 }
@@ -399,7 +399,7 @@ impl VPageAddr for V512GA {
         V512GA(va)
     }
 
-    fn address(self) -> usize {
+    fn addr(self) -> usize {
         self.0
     }
 }

--- a/x86_64/src/lib.rs
+++ b/x86_64/src/lib.rs
@@ -137,7 +137,7 @@ impl Page for Page4K {
     type VPageAddrType = V4KA;
 
     fn vaddr(&self) -> V4KA {
-        V4KA(self.0.as_ptr() as usize)
+        V4KA(self.0.as_ptr().addr())
     }
 }
 
@@ -149,7 +149,7 @@ impl Page for Page2M {
     type VPageAddrType = V2MA;
 
     fn vaddr(&self) -> V2MA {
-        V2MA(self.0.as_ptr() as usize)
+        V2MA(self.0.as_ptr().addr())
     }
 }
 
@@ -164,7 +164,7 @@ impl Page for Page1G {
     type VPageAddrType = V1GA;
 
     fn vaddr(&self) -> V1GA {
-        V1GA(self.0.as_ptr() as usize)
+        V1GA(self.0.as_ptr().addr())
     }
 }
 
@@ -178,7 +178,7 @@ impl Page for Page512G {
     type VPageAddrType = V512GA;
 
     fn vaddr(&self) -> V512GA {
-        V512GA(self.0.as_ptr() as usize)
+        V512GA(self.0.as_ptr().addr())
     }
 }
 

--- a/x86_64/src/tss.rs
+++ b/x86_64/src/tss.rs
@@ -87,7 +87,7 @@ impl TSS {
     }
 
     pub fn set_stack(&mut self, index: StackIndex, stack: &mut HyperStack) {
-        let va = stack.top() as u64;
+        let va = stack.top().addr() as u64;
         let lower = va as u32;
         let upper = (va >> 32) as u32;
         match index {
@@ -128,7 +128,7 @@ impl TSS {
 
     /// Returns a fully-formed TSS descriptor for this TSS.
     pub fn descriptor(&self) -> segment::TaskStateDescriptor {
-        let va = self as *const _ as u64;
+        let va = (self as *const Self).addr() as u64;
         segment::TaskStateDescriptor::empty()
             .with_limit0(core::mem::size_of::<TSS>() as u16 - 1)
             .with_base0(va.get_bits(0..16) as u16)

--- a/x86_64/src/vm.rs
+++ b/x86_64/src/vm.rs
@@ -336,7 +336,7 @@ struct Walk(Option<L4E>, Option<L3E>, Option<L2E>, Option<L1E>);
 /// pointer in the current address space.
 #[allow(dead_code)]
 fn walk_ptr<T>(p: *const T) -> Walk {
-    walk(p as usize)
+    walk(p.addr())
 }
 
 fn walk(va: usize) -> Walk {
@@ -366,7 +366,7 @@ fn walk(va: usize) -> Walk {
 /// Translates the virtual address of the given pointer in the current
 /// address space to a host physical address.
 pub fn translate_ptr<T>(p: *const T) -> HPA {
-    translate(p as usize)
+    translate(p.addr())
 }
 
 pub fn translate(va: usize) -> HPA {


### PR DESCRIPTION
Additional changes preparing the way for `strict_provenance`.

I think there are some cases where we're going to have a hard time without a way to forge provenance: in the VM system (both primary and second-level page tables), dealing with guest memory (and in particular the guest's virtual address space) and dealing with hardware devices.