### PR TITLE
Print user friendly messages when missing deps

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -157,7 +157,8 @@ fn dist(profile: Build) -> Result<()> {
         .arg(format!("target/{}/{}/theon", target(), profile.dir()))
         .arg(format!("target/{}/{}/theon.elf32", target(), profile.dir()))
         .current_dir(workspace())
-        .status()?;
+        .status()
+        .map_err(|e| format!("objcopy failed. Have you installed llvm? {e}"))?;
     if !status.success() {
         return Err("objcopy failed".into());
     }
@@ -221,7 +222,8 @@ fn qemu(profile: Build) -> Result<()> {
         .arg("-initrd")
         .arg(arname())
         .current_dir(workspace())
-        .status()?;
+        .status()
+        .map_err(|e| format!("qemu failed. Have you installed qemu-system-x86? {e}"))?;
     if !status.success() {
         return Err("qemu failed".into());
     }


### PR DESCRIPTION
Tried running this on a system without these tools, and got the vague
ENOENT error without indication of what to do.  Fix for the next person.

Signed-off-by: Mike Waychison <mike@waychison.com>