### PR TITLE
forbid unsafe_op_in_unsafe_fn everywhere

### DIFF
--- a/devices/src/main.rs
+++ b/devices/src/main.rs
@@ -10,6 +10,7 @@
 #![feature(strict_provenance)]
 #![cfg_attr(not(test), no_main)]
 #![cfg_attr(not(test), no_std)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 libhypatia::define_segment!(init);
 

--- a/global/src/main.rs
+++ b/global/src/main.rs
@@ -10,6 +10,7 @@
 #![feature(strict_provenance)]
 #![cfg_attr(not(test), no_main)]
 #![cfg_attr(not(test), no_std)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 libhypatia::define_segment!(init);
 

--- a/libhypatia/src/lib.rs
+++ b/libhypatia/src/lib.rs
@@ -8,6 +8,7 @@
 #![feature(strict_provenance)]
 #![cfg_attr(test, allow(dead_code))]
 #![cfg_attr(not(test), no_std)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 pub mod runtime;
 pub mod panic;

--- a/memory/src/main.rs
+++ b/memory/src/main.rs
@@ -10,6 +10,7 @@
 #![feature(strict_provenance)]
 #![cfg_attr(not(test), no_main)]
 #![cfg_attr(not(test), no_std)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 libhypatia::define_segment!(init);
 

--- a/monitor/src/main.rs
+++ b/monitor/src/main.rs
@@ -10,6 +10,7 @@
 #![feature(strict_provenance)]
 #![cfg_attr(not(test), no_main)]
 #![cfg_attr(not(test), no_std)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 libhypatia::define_segment!(init);
 

--- a/scheduler/src/main.rs
+++ b/scheduler/src/main.rs
@@ -10,6 +10,7 @@
 #![feature(strict_provenance)]
 #![cfg_attr(not(test), no_main)]
 #![cfg_attr(not(test), no_std)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 libhypatia::define_segment!(init);
 

--- a/supervisor/src/main.rs
+++ b/supervisor/src/main.rs
@@ -10,6 +10,7 @@
 #![feature(strict_provenance)]
 #![cfg_attr(not(test), no_main)]
 #![cfg_attr(not(test), no_std)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 libhypatia::define_segment!(init);
 

--- a/system/src/main.rs
+++ b/system/src/main.rs
@@ -10,6 +10,7 @@
 #![feature(strict_provenance)]
 #![cfg_attr(not(test), no_main)]
 #![cfg_attr(not(test), no_std)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 libhypatia::define_task!();
 

--- a/theon/src/allocator.rs
+++ b/theon/src/allocator.rs
@@ -28,7 +28,7 @@ unsafe impl GlobalAlloc for BumpAlloc<'_> {
         if offset > heap.len() || offset + layout.size() > heap.len() {
             return core::ptr::null_mut();
         }
-        let ptr = ptr.add(offset);
+        let ptr = ptr.wrapping_add(offset);
         let heap = &mut heap[offset + layout.size()..];
         self.heap.replace(heap);
         ptr

--- a/theon/src/main.rs
+++ b/theon/src/main.rs
@@ -13,6 +13,7 @@
 #![feature(strict_provenance)]
 #![cfg_attr(not(test), no_main)]
 #![cfg_attr(not(test), no_std)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 //! # Theon: System coldboot loader
 //!

--- a/theon/src/x86_64/multiboot1.rs
+++ b/theon/src/x86_64/multiboot1.rs
@@ -12,14 +12,14 @@ use multiboot::information::{MemoryManagement, MemoryType, Multiboot, PAddr};
 
 unsafe fn phys_to_slice(phys_addr: PAddr, len: usize) -> Option<&'static [u8]> {
     let p = (theon::VZERO + phys_addr as usize) as *const u8;
-    Some(core::slice::from_raw_parts(p, len))
+    Some(unsafe { core::slice::from_raw_parts(p, len) })
 }
 
 struct MM;
 
 impl MemoryManagement for MM {
     unsafe fn paddr_to_slice(&self, phys_addr: PAddr, len: usize) -> Option<&'static [u8]> {
-        phys_to_slice(phys_addr, len)
+        unsafe { phys_to_slice(phys_addr, len) }
     }
 
     unsafe fn allocate(&mut self, _len: usize) -> Option<(PAddr, &mut [u8])> {

--- a/trace/src/main.rs
+++ b/trace/src/main.rs
@@ -10,6 +10,7 @@
 #![feature(strict_provenance)]
 #![cfg_attr(not(test), no_main)]
 #![cfg_attr(not(test), no_std)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 libhypatia::define_segment!(init);
 

--- a/uart/src/lib.rs
+++ b/uart/src/lib.rs
@@ -7,6 +7,7 @@
 
 #![feature(strict_provenance)]
 #![cfg_attr(not(test), no_std)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 mod x86_64;
 

--- a/vcpu/src/main.rs
+++ b/vcpu/src/main.rs
@@ -10,6 +10,7 @@
 #![feature(strict_provenance)]
 #![cfg_attr(not(test), no_main)]
 #![cfg_attr(not(test), no_std)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 use arch::io::Sender;
 

--- a/vm/src/main.rs
+++ b/vm/src/main.rs
@@ -10,6 +10,7 @@
 #![feature(strict_provenance)]
 #![cfg_attr(not(test), no_main)]
 #![cfg_attr(not(test), no_std)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 mod x86_64;
 

--- a/x86_64/src/lib.rs
+++ b/x86_64/src/lib.rs
@@ -50,6 +50,7 @@
 #![feature(step_trait)]
 #![feature(strict_provenance)]
 #![cfg_attr(not(test), no_std)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 use core::convert::TryFrom;
 use core::fmt::Debug;

--- a/x86_64/src/trap.rs
+++ b/x86_64/src/trap.rs
@@ -105,11 +105,13 @@ pub fn stubs() -> &'static [Stub; 256] {
 #[link_section = ".trap"]
 #[naked]
 pub unsafe extern "C" fn trap_stubs() -> ! {
-    asm!(
-        seq!(N in 0..=255 {
-            concat!( #( gen_trap_stub!(N), )* )
-        }),
-        trap = sym trap, options(att_syntax, noreturn));
+    unsafe {
+        asm!(
+            seq!(N in 0..=255 {
+                concat!( #( gen_trap_stub!(N), )* )
+            }),
+            trap = sym trap, options(att_syntax, noreturn));
+    }
 }
 
 /// # Safety
@@ -118,95 +120,97 @@ pub unsafe extern "C" fn trap_stubs() -> ! {
 #[link_section = ".trap"]
 #[naked]
 pub unsafe extern "C" fn trap() -> ! {
-    asm!(r#"
-        // Allocate space to save registers.
-        subq $((4 + 15) * 8), %rsp
-        // Save the x86 segmentation registers.
-        movq $0, 18*8(%rsp);
-        movw %gs, 18*8(%rsp);
-        movq $0, 17*8(%rsp);
-        movw %fs, 17*8(%rsp);
-        movq $0, 16*8(%rsp);
-        movw %es, 16*8(%rsp);
-        movq $0, 15*8(%rsp);
-        movw %ds, 15*8(%rsp);
-        // Save the general purpose registers.
-        movq %r15, 14*8(%rsp);
-        movq %r14, 13*8(%rsp);
-        movq %r13, 12*8(%rsp);
-        movq %r12, 11*8(%rsp);
-        movq %r11, 10*8(%rsp);
-        movq %r10, 9*8(%rsp);
-        movq %r9, 8*8(%rsp);
-        movq %r8, 7*8(%rsp);
-        movq %rbp, 6*8(%rsp);
-        movq %rdi, 5*8(%rsp);
-        movq %rsi, 4*8(%rsp);
-        movq %rdx, 3*8(%rsp);
-        movq %rcx, 2*8(%rsp);
-        movq %rbx, 1*8(%rsp);
-        movq %rax, 0*8(%rsp);
-        // Fix up the vector number.  We got into `trap` via a
-        // CALL, so hardware pushed the address after after the
-        // CALLQ instruction onto the stack, and the byte at that
-        // location is the vector number from the stub.  Load
-        // the "return" address from the stack, then MOVZBQ what
-        // that points to into %rdi, and store back in the save
-        // area.
-        //
-        // The vector number is an argument to the dispatch
-        // function, along with the address of the register save
-        // area at the top of the stack.
-        movq {vector_offset}(%rsp), %rdi;
-        movzbq (%rdi), %rdi;
-        movq %rdi, {vector_offset}(%rsp);
-        movq %rsp, %rsi;
-        // If we're already in kernel mode, don't swap %gs.
-        cmpq ${ktext_sel}, {cs_offset}(%rsp);
-        je 1f;
-        swapgs;
-        1:
-        callq {dispatch};
-        // If we're returning to kernel mode, don't swap %gs.
-        cmpq ${ktext_sel}, {cs_offset}(%rsp);
-        je 1f;
-        swapgs;
-        1:
-        // Restore the general purpose registers.
-        movq 0*8(%rsp), %rax;
-        movq 1*8(%rsp), %rbx;
-        movq 2*8(%rsp), %rcx;
-        movq 3*8(%rsp), %rdx;
-        movq 4*8(%rsp), %rsi;
-        movq 5*8(%rsp), %rdi;
-        movq 6*8(%rsp), %rbp;
-        movq 7*8(%rsp), %r8;
-        movq 8*8(%rsp), %r9;
-        movq 9*8(%rsp), %r10;
-        movq 10*8(%rsp), %r11;
-        movq 11*8(%rsp), %r12;
-        movq 12*8(%rsp), %r13;
-        movq 13*8(%rsp), %r14;
-        movq 14*8(%rsp), %r15;
-        // Restore the segmentation registers.
-        movw 15*8(%rsp), %ds;
-        movw 16*8(%rsp), %es;
-        // %gs is restored via swapgs above.  The system never changes
-        // it, so we don't bother restoring it here.  %fs is special.
-        // We do save and restore it, for TLS if anyone ever uses green
-        // threads.
-        movw 17*8(%rsp), %fs;
-        // movw 18*8(%rsp), %gs;
-        // Pop registers, alignment word and error.
-        addq $((2 + 4 + 15) * 8), %rsp;
-        // Go back to whence you came.
-        iretq
-        "#,
-        ktext_sel = const 8,
-        cs_offset = const TRAPFRAME_CS_OFFSET,
-        vector_offset = const TRAPFRAME_VECTOR_OFFSET,
-        dispatch = sym dispatch,
-        options(att_syntax, noreturn));
+    unsafe {
+        asm!(r#"
+            // Allocate space to save registers.
+            subq $((4 + 15) * 8), %rsp
+            // Save the x86 segmentation registers.
+            movq $0, 18*8(%rsp);
+            movw %gs, 18*8(%rsp);
+            movq $0, 17*8(%rsp);
+            movw %fs, 17*8(%rsp);
+            movq $0, 16*8(%rsp);
+            movw %es, 16*8(%rsp);
+            movq $0, 15*8(%rsp);
+            movw %ds, 15*8(%rsp);
+            // Save the general purpose registers.
+            movq %r15, 14*8(%rsp);
+            movq %r14, 13*8(%rsp);
+            movq %r13, 12*8(%rsp);
+            movq %r12, 11*8(%rsp);
+            movq %r11, 10*8(%rsp);
+            movq %r10, 9*8(%rsp);
+            movq %r9, 8*8(%rsp);
+            movq %r8, 7*8(%rsp);
+            movq %rbp, 6*8(%rsp);
+            movq %rdi, 5*8(%rsp);
+            movq %rsi, 4*8(%rsp);
+            movq %rdx, 3*8(%rsp);
+            movq %rcx, 2*8(%rsp);
+            movq %rbx, 1*8(%rsp);
+            movq %rax, 0*8(%rsp);
+            // Fix up the vector number.  We got into `trap` via a
+            // CALL, so hardware pushed the address after after the
+            // CALLQ instruction onto the stack, and the byte at that
+            // location is the vector number from the stub.  Load
+            // the "return" address from the stack, then MOVZBQ what
+            // that points to into %rdi, and store back in the save
+            // area.
+            //
+            // The vector number is an argument to the dispatch
+            // function, along with the address of the register save
+            // area at the top of the stack.
+            movq {vector_offset}(%rsp), %rdi;
+            movzbq (%rdi), %rdi;
+            movq %rdi, {vector_offset}(%rsp);
+            movq %rsp, %rsi;
+            // If we're already in kernel mode, don't swap %gs.
+            cmpq ${ktext_sel}, {cs_offset}(%rsp);
+            je 1f;
+            swapgs;
+            1:
+            callq {dispatch};
+            // If we're returning to kernel mode, don't swap %gs.
+            cmpq ${ktext_sel}, {cs_offset}(%rsp);
+            je 1f;
+            swapgs;
+            1:
+            // Restore the general purpose registers.
+            movq 0*8(%rsp), %rax;
+            movq 1*8(%rsp), %rbx;
+            movq 2*8(%rsp), %rcx;
+            movq 3*8(%rsp), %rdx;
+            movq 4*8(%rsp), %rsi;
+            movq 5*8(%rsp), %rdi;
+            movq 6*8(%rsp), %rbp;
+            movq 7*8(%rsp), %r8;
+            movq 8*8(%rsp), %r9;
+            movq 9*8(%rsp), %r10;
+            movq 10*8(%rsp), %r11;
+            movq 11*8(%rsp), %r12;
+            movq 12*8(%rsp), %r13;
+            movq 13*8(%rsp), %r14;
+            movq 14*8(%rsp), %r15;
+            // Restore the segmentation registers.
+            movw 15*8(%rsp), %ds;
+            movw 16*8(%rsp), %es;
+            // %gs is restored via swapgs above.  The system never changes
+            // it, so we don't bother restoring it here.  %fs is special.
+            // We do save and restore it, for TLS if anyone ever uses green
+            // threads.
+            movw 17*8(%rsp), %fs;
+            // movw 18*8(%rsp), %gs;
+            // Pop registers, alignment word and error.
+            addq $((2 + 4 + 15) * 8), %rsp;
+            // Go back to whence you came.
+            iretq
+            "#,
+            ktext_sel = const 8,
+            cs_offset = const TRAPFRAME_CS_OFFSET,
+            vector_offset = const TRAPFRAME_VECTOR_OFFSET,
+            dispatch = sym dispatch,
+            options(att_syntax, noreturn));
+    }
 }
 
 fn dispatch(_vector: u8, _trap_frame: &mut Frame) -> u32 {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -5,6 +5,8 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+#![forbid(unsafe_op_in_unsafe_fn)]
+
 use std::{
     env,
     path::{Path, PathBuf},


### PR DESCRIPTION
Forbid the use of unsafe operations in `unsafe fn`s without
an explicit `unsafe` block.  I just heard about the feature
yesterday; it was a long time coming.

While the number of occurrences of the `unsafe` keyword
increases with this change, the total amount of actual
unsafe _code_ decreases.

Signed-off-by: Dan Cross <cross@gajendra.net>