### PR TITLE
Cargo.toml: `opt-level = 1` for debug builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
 
 [profile.dev]
 panic = "abort"
+opt-level = 1  # enables enough optimization for reasonable stack usage
 
 [profile.release]
 panic = "abort"


### PR DESCRIPTION
Stack usage for debug builds was unacceptably large.  Enable just enough optimization to reduce this, while still generating reasonably sight-debuggable object code.

Signed-off-by: Dan Cross <cross@gajendra.net>