### PR TITLE
Cargo.toml: add debug = 1 for release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,4 @@ opt-level = 1  # enables enough optimization for reasonable stack usage
 
 [profile.release]
 panic = "abort"
+debug = 1


### PR DESCRIPTION
This proved useful while poking around at the release build, and shouldn't cause any harm to carry in the build artifacts.